### PR TITLE
Add support for Mangler charged shots when attack2fire is enabled

### DIFF
--- a/jumpqol.sp
+++ b/jumpqol.sp
@@ -2846,7 +2846,7 @@ MRESReturn Attack2fire_Detour_Pre_CTFWeaponBase__ItemPostFrame(int entity)
     if (!IsActivePlayer(client))
         return MRES_Ignored;
 
-    if (!g_sessions[client].attack2fire)
+    if (g_sessions[client].attack2fire == 0)
         return MRES_Ignored;
 
     char classname[64];
@@ -2860,11 +2860,19 @@ MRESReturn Attack2fire_Detour_Pre_CTFWeaponBase__ItemPostFrame(int entity)
         return MRES_Ignored;
 
     bool isenergyweapon = StrEqual(classname, "tf_weapon_particle_cannon");
+    bool isfullycharged = isenergyweapon ? SDKCall(g_Call_Energy_FullyCharged, entity) : false;
 
-    if ((!isenergyweapon && GetEntProp(entity, Prop_Data, "m_iClip1") != 0) || (isenergyweapon && !SDKCall(g_Call_Energy_FullyCharged, entity)))
-        SetEntPropFloat(entity, Prop_Send, "m_flNextSecondaryAttack", g_globals.curtime + 0.5);
-    else
+    if (g_sessions[client].attack2fire == 1 && isenergyweapon && isfullycharged && !g_chargemsg[client]) {
+        if (GetClientButtons(client) & IN_ATTACK2) {
+            PrintToChat(client, "\x07FFFFFFUse\x074FDDFF !jumpqol attack2fire 2 \x07FFFFFFto allow Cow Mangler 5000 charged shots");
+            g_chargemsg[client] = !g_chargemsg[client];
+        }
+    }
+
+    if ((!isenergyweapon && GetEntProp(entity, Prop_Data, "m_iClip1") == 0) || (isenergyweapon && isfullycharged && g_sessions[client].attack2fire == 2))
         SetEntPropFloat(entity, Prop_Send, "m_flNextSecondaryAttack", g_globals.curtime - g_globals.interval_per_tick);
+    else
+        SetEntPropFloat(entity, Prop_Send, "m_flNextSecondaryAttack", g_globals.curtime + 0.5);
 
     return MRES_Handled;
 }

--- a/jumpqol.sp
+++ b/jumpqol.sp
@@ -1873,6 +1873,7 @@ public void OnPluginStart()
     g_settings[SETTING_ATTACK2FIRE].desc = "Lets you shoot rockets while attack2 is pressed.";
     g_settings[SETTING_ATTACK2FIRE].expl = "";
     g_settings[SETTING_ATTACK2FIRE].type = SETTING_BOOL;
+    g_settings[SETTING_ATTACK2FIRE].f_init = Attack2fire_Init;
     g_settings[SETTING_ATTACK2FIRE].f_start = Attack2fire_Start;
     g_settings[SETTING_ATTACK2FIRE].f_stop = Attack2fire_Stop;
     g_settings[SETTING_ATTACK2FIRE].f_active = SettingActiveDefaultBool;
@@ -2802,6 +2803,22 @@ _attack2fire
 
 
 
+
+Handle g_Call_Energy_FullyCharged;
+bool Attack2fire_Init()
+{
+    StartPrepSDKCall(SDKCall_Entity);
+    if (!PrepSDKCall_SetFromConf(g_gameconf, SDKConf_Signature, "CTFWeaponBase::Energy_FullyCharged"))
+        return SetError("Failed to prepare CTFWeaponBase::Energy_FullyCharged call.");
+
+    PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_ByValue);
+
+    g_Call_Energy_FullyCharged = EndPrepSDKCall();
+    if (g_Call_Energy_FullyCharged == INVALID_HANDLE)
+        return SetError("Failed to prepare CTFWeaponBase::Energy_FullyCharged call.");
+
+    return true;
+}
 
 bool Attack2fire_Start()
 {

--- a/jumpqol.sp
+++ b/jumpqol.sp
@@ -1632,7 +1632,7 @@ methodmap Session
         }
     }
 
-    property bool attack2fire
+    property int attack2fire
     {
         public get()
         {
@@ -1871,15 +1871,15 @@ public void OnPluginStart()
 
     g_settings[SETTING_ATTACK2FIRE].name = "attack2fire";
     g_settings[SETTING_ATTACK2FIRE].desc = "Lets you shoot rockets while attack2 is pressed.";
-    g_settings[SETTING_ATTACK2FIRE].expl = "";
-    g_settings[SETTING_ATTACK2FIRE].type = SETTING_BOOL;
+    g_settings[SETTING_ATTACK2FIRE].expl = "0: Disable.\n1: Block attack2 from all primary rocket launchers.\n2: Allow Cow Mangler 5000 charged shots.";
+    g_settings[SETTING_ATTACK2FIRE].type = SETTING_INT;
     g_settings[SETTING_ATTACK2FIRE].f_init = Attack2fire_Init;
     g_settings[SETTING_ATTACK2FIRE].f_start = Attack2fire_Start;
     g_settings[SETTING_ATTACK2FIRE].f_stop = Attack2fire_Stop;
-    g_settings[SETTING_ATTACK2FIRE].f_active = SettingActiveDefaultBool;
+    g_settings[SETTING_ATTACK2FIRE].f_active = SettingActiveDefaultIntG;
     g_settings[SETTING_ATTACK2FIRE].range[0] = 0.0;
-    g_settings[SETTING_ATTACK2FIRE].range[1] = 1.0;
-    g_settings[SETTING_ATTACK2FIRE].Init(true, false);
+    g_settings[SETTING_ATTACK2FIRE].range[1] = 2.0;
+    g_settings[SETTING_ATTACK2FIRE].Init(1, false);
 
     g_settings[SETTING_RAMPFIX].name = "rampfix";
     g_settings[SETTING_RAMPFIX].desc = "Prevents the event where you sometimes stop up on a ramp you should have been able to slide up.";

--- a/jumpqol.sp
+++ b/jumpqol.sp
@@ -2852,7 +2852,9 @@ MRESReturn Attack2fire_Detour_Pre_CTFWeaponBase__ItemPostFrame(int entity)
     )
         return MRES_Ignored;
 
-    if (GetEntProp(entity, Prop_Data, "m_iClip1") != 0)
+    bool isenergyweapon = StrEqual(classname, "tf_weapon_particle_cannon");
+
+    if ((!isenergyweapon && GetEntProp(entity, Prop_Data, "m_iClip1") != 0) || (isenergyweapon && !SDKCall(g_Call_Energy_FullyCharged, entity)))
         SetEntPropFloat(entity, Prop_Send, "m_flNextSecondaryAttack", g_globals.curtime + 0.5);
     else
         SetEntPropFloat(entity, Prop_Send, "m_flNextSecondaryAttack", g_globals.curtime - g_globals.interval_per_tick);

--- a/jumpqol.sp
+++ b/jumpqol.sp
@@ -490,6 +490,7 @@ bool g_inside_cmd = false;
 
 bool g_allow_update = false;
 
+bool g_chargemsg[MAXPLAYERS+1];
 
 
 
@@ -1487,6 +1488,7 @@ methodmap Session
 
     public void Clear()
     {
+        this.ResetChargeMessage();
         this.ClearProjectiles();
     }
 
@@ -1531,6 +1533,11 @@ methodmap Session
 
         for (int setting = 0; setting < NUM_SETTINGS; setting++)
             g_settings[setting].SetActive(this.client, false);
+    }
+
+    public void ResetChargeMessage()
+    {
+        g_chargemsg[this.client] = false;
     }
 
     public void ClearProjectiles()

--- a/jumpqol.txt
+++ b/jumpqol.txt
@@ -76,6 +76,12 @@
                 "linux"     "@_ZN13CTFWeaponBase13ItemPostFrameEv"
             }
 
+            "CTFWeaponBase::Energy_FullyCharged"
+            {
+                "library"   "server"
+                "linux"     "@_ZNK13CTFWeaponBase19Energy_FullyChargedEv"
+            }
+
             "CTFGameMovement::SetGroundEntity"
             {
                 "library"   "server"


### PR DESCRIPTION
Currently alt-fire charged shots do not work with the Cow Mangler 5000 when attack2fire is enabled because `m_flNextSecondaryAttack` will always be set to `g_globals.curtime + 0.5`:
https://github.com/chrb22/jumpqol/blob/306739dc88b5882a097908411d887adbd94ec50d/jumpqol.sp#L2838-L2841

This PR adds a check for if the Mangler is fully charged, and if so, sets `m_flNextSecondaryAttack` to `g_globals.curtime - g_globals.interval_per_tick`. 

The Mangler is not affected by the same reload problem fixed in 9002a10 when all ammo runs out (+ `m_iClip1` doesn't decrement), so that check no longer runs.